### PR TITLE
Allow Pessoa optional bet fields

### DIFF
--- a/src/models/pessoa_models.py
+++ b/src/models/pessoa_models.py
@@ -1,5 +1,22 @@
 class Pessoa:
-    def __init__(self, nome, idm, saldo, score, valor_aposta, oponente):
+    def __init__(self, nome, idm, saldo, score, valor_aposta=None, oponente=None):
+        """Cria uma nova pessoa.
+
+        Parameters
+        ----------
+        nome : str
+            Nome da pessoa.
+        idm : str
+            Identificador único da pessoa.
+        saldo : int | float
+            Saldo inicial disponível.
+        score : int
+            Score inicial da pessoa.
+        valor_aposta : int | float | None, optional
+            Valor da aposta atual da pessoa. ``None`` indica que não há aposta registrada.
+        oponente : Pessoa | None, optional
+            Oponente da pessoa em uma aposta/desafio. ``None`` indica que não há oponente definido.
+        """
         self.nome = nome
         self.idm = idm
         self.saldo = saldo


### PR DESCRIPTION
## Summary
- make `valor_aposta` and `oponente` optional in `Pessoa`
- document optional parameters in new docstring

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f80576314832c8bf23941d083bdfb